### PR TITLE
Trivy vulnerabilities fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ passlib==1.7.4
 pluggy==1.4.0
 psycopg==3.1.18
 psycopg2-binary==2.9.9
-pyasn1==0.6.0
+pyasn1==0.4.8
 pycparser==2.22
 pydantic==2.6.4
 pydantic-settings==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ email_validator==2.1.1
 exceptiongroup==1.2.0
 factory-boy==3.3.0
 Faker==24.4.0
-fastapi==0.110.0
+fastapi==0.115.5
 greenlet==3.0.3
 gunicorn==22.0.0
 h11==0.14.0
@@ -39,7 +39,7 @@ pycparser==2.22
 pydantic==2.6.4
 pydantic-settings==2.2.1
 pydantic_core==2.16.3
-PyMySQL==1.1.0
+PyMySQL==1.1.1
 pypng==0.20220715.0
 pytest==8.1.1
 pytest-asyncio==0.23.6
@@ -48,13 +48,13 @@ pytest-mock==3.14.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
 python-jose==3.3.0
-python-multipart==0.0.9
+python-multipart==0.0.18
 qrcode==7.4.2
 rsa==4.9
 six==1.16.0
 sniffio==1.3.1
 SQLAlchemy==2.0.29
-starlette==0.36.3
+starlette==0.41.3
 tomli==2.0.1
 typing_extensions==4.10.0
 uvicorn==0.29.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,8 +21,8 @@ factory-boy==3.3.0
 Faker==24.4.0
 fastapi==0.115.5
 greenlet==3.0.3
-gunicorn==22.0.0
-h11==0.14.0
+gunicorn==23.0.0
+h11==0.16.0
 httpcore==1.0.5
 httpx==0.27.0
 idna==3.6
@@ -47,7 +47,7 @@ pytest-cov==5.0.0
 pytest-mock==3.14.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
-python-jose==3.3.0
+python-jose==3.4.0
 python-multipart==0.0.18
 qrcode==7.4.2
 rsa==4.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ fastapi==0.115.5
 greenlet==3.0.3
 gunicorn==23.0.0
 h11==0.16.0
-httpcore==1.0.5
+httpcore>=1.0.6
 httpx==0.27.0
 idna==3.6
 iniconfig==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,9 +21,9 @@ factory-boy==3.3.0
 Faker==24.4.0
 fastapi
 greenlet==3.0.3
-gunicorn==22.0.0
-h11==0.14.0
-httpcore==1.0.5
+gunicorn
+h11
+httpcore
 httpx==0.27.0
 idna==3.6
 iniconfig==2.0.0
@@ -47,7 +47,7 @@ pytest-cov==5.0.0
 pytest-mock==3.14.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
-python-jose==3.3.0
+python-jose
 python-multipart
 qrcode==7.4.2
 rsa==4.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,9 +21,9 @@ factory-boy==3.3.0
 Faker==24.4.0
 fastapi==0.115.5
 greenlet==3.0.3
-gunicorn==23.0.0
-h11==0.16.0
-httpcore>=1.0.6
+gunicorn==22.0.0
+h11==0.14.0
+httpcore==1.0.5
 httpx==0.27.0
 idna==3.6
 iniconfig==2.0.0
@@ -47,7 +47,7 @@ pytest-cov==5.0.0
 pytest-mock==3.14.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
-python-jose==3.4.0
+python-jose==3.3.0
 python-multipart==0.0.18
 qrcode==7.4.2
 rsa==4.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ pytest-cov==5.0.0
 pytest-mock==3.14.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
-python-jose
+python-jose==3.4.0
 python-multipart
 qrcode==7.4.2
 rsa==4.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ email_validator==2.1.1
 exceptiongroup==1.2.0
 factory-boy==3.3.0
 Faker==24.4.0
-fastapi==0.115.5
+fastapi
 greenlet==3.0.3
 gunicorn==22.0.0
 h11==0.14.0
@@ -39,7 +39,7 @@ pycparser==2.22
 pydantic==2.6.4
 pydantic-settings==2.2.1
 pydantic_core==2.16.3
-PyMySQL==1.1.1
+PyMySQL
 pypng==0.20220715.0
 pytest==8.1.1
 pytest-asyncio==0.23.6
@@ -48,13 +48,13 @@ pytest-mock==3.14.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
 python-jose==3.3.0
-python-multipart==0.0.18
+python-multipart
 qrcode==7.4.2
 rsa==4.9
 six==1.16.0
 sniffio==1.3.1
 SQLAlchemy==2.0.29
-starlette==0.41.3
+starlette
 tomli==2.0.1
 typing_extensions==4.10.0
 uvicorn==0.29.0


### PR DESCRIPTION
Fixes #3 

Fix: Upgraded High and critical trivy vulnerabilities with version upgrading in requirements.txt.