### PR TITLE
password strength validation

### DIFF
--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -36,6 +36,25 @@ class UserBase(BaseModel):
 class UserCreate(UserBase):
     email: EmailStr = Field(..., example="john.doe@example.com")
     password: str = Field(..., example="Secure*1234")
+    @validator('password')
+    def validate_password(cls, password):
+        errors = []
+
+        if len(password) < 8:
+            errors.append("Password must be at least 8 characters long.")
+        if not any(char.isupper() for char in password):
+            errors.append("Password must include at least one uppercase letter.")
+        if not any(char.islower() for char in password):
+            errors.append("Password must include at least one lowercase letter.")
+        if not any(char.isdigit() for char in password):
+            errors.append("Password must include at least one number.")
+        if not any(char in "!@#$%^&*(),.?\":{}|<>" for char in password):
+            errors.append("Password must include at least one special character (!@#$%^&*(),.?\":{}|<>).")
+
+        if errors:
+            raise ValueError(" ".join(errors)) 
+
+        return password
 
 class UserUpdate(UserBase):
     email: Optional[EmailStr] = Field(None, example="john.doe@example.com")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from builtins import Exception, range, str
 from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
+import uuid
 
 # Third-party imports
 import pytest
@@ -238,3 +239,15 @@ def email_service():
         mock_service.send_verification_email.return_value = None
         mock_service.send_user_email.return_value = None
         return mock_service
+
+
+@pytest.fixture
+def generate_unique_user():
+    """Generates a user dictionary with unique nickname and email."""
+    return {
+        "nickname": f"testuser_{uuid.uuid4().hex[:6]}",
+        "email": f"test_{uuid.uuid4().hex[:6]}@testmail.com",
+        "first_name": "Test",
+        "last_name": "Case",
+        "role": "AUTHENTICATED"
+    }


### PR DESCRIPTION
Fixes #5 

A new @validator was added in the UserCreate Pydantic model to enforce password strength.

The validator checks for:

Minimum length (8 characters)

At least one uppercase

At least one lowercase

At least one number

At least one special character